### PR TITLE
Make secure cookie configuration via docker env

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -26,6 +26,9 @@ services:
     # - NAIKAN_LDAP_USERS_SEARCH_BASE=
     # - NAIKAN_LDAP_USERS_SEARCH_FILTER=
     #
+    # Server Properties
+    # - NAIKAN_SERVER_COOKIE_SECURE=false
+    #
     # Optional Cross-Origin Resource Sharing (CORS) Headers
     # - NAIKAN_CORS_ENABLED=true
     # - NAIKAN_CORS_ALLOW_ORIGIN=*

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -84,6 +84,12 @@ Following some example configurations that are known to work of each server impl
 
 #### JVM
 
+| Property                        | Default | Description                                   |
+|:--------------------------------|:--------|:----------------------------------------------|
+| `NAIKAN_SERVER_COOKIE_SECURE`   | false   | Whether to always mark the cookie as secure.  |
+
+#### JVM
+
 | Property               | Default | Description                                                                       |
 |:-----------------------|:--------|:----------------------------------------------------------------------------------|
 | `EXTRA_JAVA_OPTIONS`   |         | To provide more JVM arguments to the JVM, <br/>i.e. `-XX:ActiveProcessorCount=4`  |

--- a/naikan-web/src/main/resources/application.yml
+++ b/naikan-web/src/main/resources/application.yml
@@ -31,7 +31,7 @@ server:
     session:
       timeout: 7200s
       cookie:
-        secure: true
+        secure: ${NAIKAN_SERVER_COOKIE_SECURE:false}
   compression:
     enabled: true
     mime-types:


### PR DESCRIPTION
* Configurable via NAIKAN_SERVER_COOKIE_SECURE
* Secure cookie is now set to false.

Closes gb-43